### PR TITLE
fix case error in setOpts() call for DELETE method

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -104,7 +104,7 @@ class PrivateAPI {
 
 				break;
 			case 'DELETE':
-				$this->setopts([
+				$this->setOpts([
 					CURLOPT_CUSTOMREQUEST => 'DELETE',
 					CURLOPT_URL => $url
 				]);


### PR DESCRIPTION
Just a little thing that I ran across today when deleting discount codes