### PR TITLE
Unsupported Browser bypass

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -75,7 +75,7 @@ class PrivateAPI {
 		return ($http_code == 200 && $this->setToken($data));
 	}
 
-    public function browserBypass($data) {
+	public function browserBypass($data) {
 		if (strpos($data, self::_BROWSER_BYPASS_URL) === false) {
 			return $data;
 		}

--- a/shopify.php
+++ b/shopify.php
@@ -5,7 +5,7 @@ namespace Shopify;
 class PrivateAPI {
 	const _LOGIN_URL = 'auth/login';
 	const _REPORT_CENTER = 'https://reportcenter.shopify.com/';
-    const _BROWSER_BYPASS_URL = 'unsupported_browser_bypass';
+	const _BROWSER_BYPASS_URL = 'unsupported_browser_bypass';
 	
 	const _COOKIE_STORE = '/tmp/shopify_cookie.txt';
 	const _USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36';
@@ -70,27 +70,28 @@ class PrivateAPI {
 
 		$data = curl_exec($this->ch);
 		$http_code = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
-        $data = $this->browserBypass($data);
+		$data = $this->browserBypass($data);
 
 		return ($http_code == 200 && $this->setToken($data));
 	}
 
     public function browserBypass($data) {
-        if (strpos($data, self::_BROWSER_BYPASS_URL) === false) {
-            return $data;
-        }
+		if (strpos($data, self::_BROWSER_BYPASS_URL) === false) {
+			return $data;
+		}
 
-        $url = $this->store . self::_BROWSER_BYPASS_URL;
-        $this->ch = curl_init($url);
-        $this->setOpts();
-        $data = curl_exec($this->ch);
+		$url = $this->store . self::_BROWSER_BYPASS_URL;
+		$this->ch = curl_init($url);
+		$this->setOpts();
+		$data = curl_exec($this->ch);
 
 		$http_code = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
-        if ($http_code != 200) {
+		if ($http_code != 200) {
 			throw new \Exception("GET [$url] got $http_code response -- details from cURL: " . curl_error($this->ch));
-        }
+		}
 
-        return $data;
+		return $data;
+	}
 
 	public function doRequest($method, $function, $parameters) {
 		$this->ch = curl_init();		


### PR DESCRIPTION
Here's a more permanent fix for Shopify's 'unsupported browser' warning. Not sure if updating the user-agent string even does anything but calling the bypass URL seems to work for me.
